### PR TITLE
Hide scrollbars by fixing the textarea size

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,13 +6,16 @@ html, body {
 }
 
 #typingCanvas {
-    width: 100%;
-    height: 100%;
+    --padding: 20px;
+
+    width: calc(100% - 2 * var(--padding));
+    height: calc(100% - 2 * var(--padding));
+
     border: none;
     outline: none; /* Removes the default focus outline */
     background: transparent; /* Makes the textarea background transparent */
     margin: 0;
-    padding: 20px; /* Adds some padding for better text positioning */
+    padding: var(--padding); /* Adds some padding for better text positioning */
     resize: none;
     font-family: "Lucida Console", "Courier New", monospace;
     font-size: 20px;


### PR DESCRIPTION
The width & height equal to 100% means that the textarea is 100% the viewport plus twice the padding. That means the textarea is bigger than the viewport.

Fix this by setting the textarea size to the viewport minus twice the padding on both axis; that means the textarea is exactly the viewport size.